### PR TITLE
Simplify API by exporting "proxy" functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,12 @@ only loads the actually relevant code.
 
 ```js
 import {
-  fileOpenPromise,
-  fileSavePromise,
+  fileOpen,
+  fileSave,
 } from 'https://unpkg.com/browser-nativefs';
 
 (async () => {
-  // This dynamically either loads the Native File System API
-  // or the legacy module.
-  const fileOpen = (await fileOpenPromise).default;
-  const fileSave = (await fileSavePromise).default;
+  // These methods will use the Native File System API or a fallback implementation.
 
   // Open a file.
   const blob = await fileOpen({mimeTypes: ['image/*']});

--- a/demo/script.mjs
+++ b/demo/script.mjs
@@ -15,15 +15,12 @@
  */
 
 import {
-  fileOpenPromise,
-  fileSavePromise,
+  fileOpen,
+  fileSave,
   imageToBlob,
 } from '../src/index.js';
 
 (async () => {
-  const fileOpen = (await fileOpenPromise).default;
-  const fileSave = (await fileSavePromise).default;
-
   const openButton = document.querySelector('#open');
   const openMultipleButton = document.querySelector('#open-multiple');
   const saveButton = document.querySelector('#save');

--- a/src/file-open.mjs
+++ b/src/file-open.mjs
@@ -15,7 +15,7 @@
  */
 // @license © 2020 Google LLC. Licensed under the Apache License, Version 2.0.
 
-const implementation = 'chooseFileSystemEntries' in window
+const implementation = 'chooseFileSystemEntries' in self
   ? import('./file-open-nativefs.mjs')
   : import('./file-open-legacy.mjs');
 

--- a/src/file-open.mjs
+++ b/src/file-open.mjs
@@ -15,13 +15,14 @@
  */
 // @license © 2020 Google LLC. Licensed under the Apache License, Version 2.0.
 
+const implementation = 'chooseFileSystemEntries' in window
+  ? import('./file-open-nativefs.mjs')
+  : import('./file-open-legacy.mjs');
+
 /**
  * For opening files, dynamically either loads the Native File System API module
  * or the legacy method.
  */
-export const fileOpenPromise = (async () => {
-  if ('chooseFileSystemEntries' in window) {
-    return await import('./file-open-nativefs.mjs');
-  }
-  return await import('./file-open-legacy.mjs');
-})();
+export async function fileOpen(...args) {
+  return (await implementation).default.call(this, ...args);
+}

--- a/src/file-save.mjs
+++ b/src/file-save.mjs
@@ -15,7 +15,7 @@
  */
 // @license © 2020 Google LLC. Licensed under the Apache License, Version 2.0.
 
-const implementation = 'chooseFileSystemEntries' in window
+const implementation = 'chooseFileSystemEntries' in self
   ? import('./file-save-nativefs.mjs')
   : import('./file-save-legacy.mjs');
 

--- a/src/file-save.mjs
+++ b/src/file-save.mjs
@@ -15,13 +15,14 @@
  */
 // @license © 2020 Google LLC. Licensed under the Apache License, Version 2.0.
 
+const implementation = 'chooseFileSystemEntries' in window
+  ? import('./file-save-nativefs.mjs')
+  : import('./file-save-legacy.mjs');
+
 /**
  * For saving files, dynamically either loads the Native File System API module
  * or the legacy method.
  */
-export const fileSavePromise = (async () => {
-  if ('chooseFileSystemEntries' in window) {
-    return await import('./file-save-nativefs.mjs');
-  }
-  return await import('./file-save-legacy.mjs');
-})();
+export async function fileSave(...args) {
+  return (await implementation).default.call(this, ...args);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,6 @@
 /**
  * @module browser-nativefs
  */
-export {fileOpenPromise} from './file-open.mjs';
-export {fileSavePromise} from './file-save.mjs';
+export {fileOpen} from './file-open.mjs';
+export {fileSave} from './file-save.mjs';
 export {imageToBlob} from './image-to-blob.mjs';


### PR DESCRIPTION
#### Before:

```js
import { fileOpenPromise } from 'https://unpkg.com/browser-nativefs';

(async () => {
  const fileOpen = (await fileOpenPromise).default;

  const blob = await fileOpen({ mimeTypes: ['image/*'] });
})();
```

#### After:

```js
import { fileOpen } from 'https://unpkg.com/browser-nativefs';

(async () => {
  // fileOpen internally loads the implementation and delegates to it
  const blob = await fileOpen({ mimeTypes: ['image/*'] });
})();
```